### PR TITLE
Removes extraneous backtick

### DIFF
--- a/packages/esds-token-compiler/README.md
+++ b/packages/esds-token-compiler/README.md
@@ -29,7 +29,7 @@ package.json
 
 {
   "scripts": {
-    "compile-tokens": "compile-tokens --watch --src=path/to/tokens.yaml` --dest=path/to/desired/destination --token-namespace=myds --format=json --format=scss"
+    "compile-tokens": "compile-tokens --watch --src=path/to/tokens.yaml --dest=path/to/desired/destination --token-namespace=myds --format=json --format=scss"
   }
 }
 ```


### PR DESCRIPTION
I copied this script and the backtick was causing an error.